### PR TITLE
Ruby: conceal 'lambda', 'proc' and 1.9 dagger lambda '->'

### DIFF
--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -1,0 +1,17 @@
+" Conceal feature required to continue (vim ≥ 7.3)
+if !has('conceal')
+    finish
+endif
+
+syntax keyword rubyLambdaKeyword lambda conceal cchar=λ
+syntax keyword rubyLambdaKeyword proc conceal cchar=λ
+hi link rubyLambdaKeyword rubyKeyword
+
+syntax match rubyLambdaOperator "->" conceal cchar=λ
+hi link rubyLambdaOperator rubyOperator
+
+hi! link Conceal rubyKeyword
+hi! link Conceal rubyOperator
+
+setlocal conceallevel=1
+setlocal concealcursor=c


### PR DESCRIPTION
While there are certain [semantic differences](http://stackoverflow.com/questions/1740046/whats-the-difference-between-a-proc-and-a-lambda-in-ruby) between them, I think it's valid to replace all of them with the lambda character.
