### PR TITLE
Lambda with Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ vim-lambdify:
 - Erlang
 - Java
 
+For Java it's necessary to change this line in the Java syntax file (`$VIMRUNTIME\syntax\java.vim`):
+
+```vim
+syn match javaError "<<<\|\.\.\|=>\|||=\|&&=\|[^-]->\|\*\/"
+```
+
+to:
+
+```vim
+syn match javaError "<<<\|\.\.\|=>\|||=\|&&=\|\*\/"
+```
+Otherwise the `->` operator will be highlighted as error.
+
 More will likely be added over time. These just happen to be languages I use
 frequently that have lambdas or something akin to them.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ vim-lambdify:
 - JavaScript
 - Scheme
 - Erlang
-
+- Java
 
 More will likely be added over time. These just happen to be languages I use
 frequently that have lambdas or something akin to them.

--- a/after/syntax/java.vim
+++ b/after/syntax/java.vim
@@ -1,0 +1,1 @@
+call vimlambdify#lambdify_match("javaOperator", "javaLambdaOperator", "\"->\"")


### PR DESCRIPTION
Adding support for lambda on Java 8+.
To work with Java it's necessary to change this line in the Java syntax file:
```
syn match javaError "<<<\|\.\.\|=>\|||=\|&&=\|[^-]->\|\*\/"
```
to:
```
syn match javaError "<<<\|\.\.\|=>\|||=\|&&=\|\*\/"
```

Source: http://egloos.zum.com/sink772/v/4890932