### PR TITLE
Add support for racket lisp

### DIFF
--- a/after/syntax/racket.vim
+++ b/after/syntax/racket.vim
@@ -1,0 +1,1 @@
+call vimlambdify#lambdify("Statement", "racketSyntax", "lambda")


### PR DESCRIPTION
This PR would add support for racket, a dialect of lisp.

Edit: relies on the presence of [wlangsroth/vim-racket](https://github.com/wlangstroth/vim-racket)